### PR TITLE
Add clear filters button to reset dashboard filters

### DIFF
--- a/app.js
+++ b/app.js
@@ -169,8 +169,22 @@ async function refresh() {
   }
 }
 
+// Išvalo paiešką, filtrus ir atstato numatytą rikiavimą.
+function clearFilters() {
+  const search = document.getElementById("search");
+  const filterStatus = document.getElementById("filterStatus");
+  const filterSLA = document.getElementById("filterSLA");
+  const sort = document.getElementById("sort");
+  if (search) search.value = "";
+  if (filterStatus) filterStatus.value = "";
+  if (filterSLA) filterSLA.value = "";
+  if (sort) sort.value = "priority";
+  refresh();
+}
+
 if (typeof document !== "undefined" && document.getElementById("refreshBtn")) {
   document.getElementById("refreshBtn").addEventListener("click", refresh);
+  document.getElementById("clearFilters").addEventListener("click", clearFilters);
   document.getElementById("filterStatus").addEventListener("change", refresh);
   document.getElementById("filterSLA").addEventListener("change", refresh);
   document.getElementById("sort").addEventListener("change", refresh);

--- a/index.html
+++ b/index.html
@@ -52,6 +52,9 @@
         <button id="refreshBtn" type="button" class="rounded-md bg-slate-900 text-white px-2 py-1 h-7 flex-none text-xs shadow hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200">
           Atnaujinti
         </button>
+        <button id="clearFilters" type="button" class="rounded-md bg-slate-900 text-white px-2 py-1 h-7 flex-none text-xs shadow hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200">
+          Išvalyti
+        </button>
         <button id="themeToggle" type="button" class="rounded-md bg-slate-900 text-white px-2 py-1 h-7 flex-none text-xs shadow hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200">
           Tamsi tema
         </button>


### PR DESCRIPTION
## Summary
- Add "Išvalyti" button next to refresh to clear all search and filter inputs.
- Implement `clearFilters` helper to reset filters and trigger `refresh()`.
- Wire up button click event to clear filters and reload data.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5665a95848320b89ff8c725fa4a04