### PR TITLE
style: make grid responsive for narrow screens

### DIFF
--- a/grid.html
+++ b/grid.html
@@ -10,8 +10,8 @@
     tailwind.config = { darkMode: 'class' };
   </script>
   <style type="text/tailwindcss">
-    .bed-cell { @apply flex flex-col items-center justify-center text-center p-2 text-xl font-semibold rounded-xl border shadow-sm transition-colors duration-150; }
-    .bed-id { @apply text-2xl font-bold; }
+    .bed-cell { @apply flex flex-col items-center justify-center text-center p-1 sm:p-2 text-xs sm:text-sm md:text-xl font-semibold rounded-xl border shadow-sm transition-colors duration-150; }
+    .bed-id { @apply text-sm sm:text-xl md:text-2xl font-bold; }
     .bed-info { @apply mt-1 text-base flex flex-col items-center gap-1; }
     .clean { @apply bg-emerald-100 text-emerald-800 border-emerald-200; }
     .occupied { @apply bg-rose-100 text-rose-800 border-rose-200; }


### PR DESCRIPTION
## Summary
- add Tailwind responsive text and padding classes for bed grid cells

## Testing
- `npm test`
- `npx playwright install chromium` *(fails: Failed to download Chromium 123.0.6312.4)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b4bc6b84832085827e494e4b2032