### PR TITLE
fix: prevent grid cell squeeze

### DIFF
--- a/grid.html
+++ b/grid.html
@@ -34,7 +34,7 @@
       </div>
     </header>
     <div id="error" class="text-red-600 mb-2 hidden"></div>
-    <div class="flex-1 flex items-center justify-center">
+    <div class="flex-1 flex items-center justify-center overflow-x-auto">
       <div id="bedGrid" class="grid gap-2"></div>
     </div>
     <footer class="mt-4 text-sm flex justify-center gap-4">

--- a/grid.js
+++ b/grid.js
@@ -35,7 +35,12 @@ function renderGrid(rows) {
   const totalGapY = gapY * (maxRow - 1);
 
   // Plotis parenkamas pagal turimą vietą, o aukštis – pagal nurodytą proporciją.
-  const cellWidth = Math.floor((availableWidth - totalGapX) / maxCol);
+  const autoCellWidth = Math.floor((availableWidth - totalGapX) / maxCol);
+  let cellWidth = Math.max(autoCellWidth, 60);
+  if (parent) {
+    if (cellWidth > autoCellWidth) parent.classList.add('overflow-x-auto');
+    else parent.classList.remove('overflow-x-auto');
+  }
   const maxHeight = Math.floor((availableHeight - totalGapY) / maxRow);
   const cellHeight = Math.min(Math.floor(cellWidth * HEIGHT_RATIO), maxHeight);
 


### PR DESCRIPTION
## Summary
- set a minimum grid cell width and adjust height accordingly
- allow horizontal scrolling when cells exceed the available space

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6b5ac6a788320bb86e8db7efea69a