### PR TITLE
Fix KPI card title clipping

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,12 +20,15 @@ function renderKPIs(rows) {
     { label: "SLA viršyta", value: rows.filter(r => r.sla === "⛔ Viršyta").length, cls: "bg-red-100 text-red-800" },
   ];
   const el = document.getElementById("kpis");
-  el.innerHTML = kpis.map(k =>
-    `<div class="card p-4 bg-white dark:bg-slate-800 flex flex-col justify-between h-24">
-         <div class="text-sm md:text-base leading-tight truncate text-slate-500 dark:text-slate-400">${k.label}</div>
-         <div class="text-4xl md:text-5xl leading-none font-semibold ${k.cls} inline-block rounded-lg px-2 py-0.5 mt-1">${k.value}</div>
-       </div>`
-  ).join("");
+  el.innerHTML = kpis
+    .map(
+      (k, idx) =>
+        `<article class="card kpi-card bg-white dark:bg-slate-800" aria-labelledby="kpi-${idx}">
+           <h3 id="kpi-${idx}" class="kpi-title" title="${k.label}">${k.label}</h3>
+           <div class="kpi-value ${k.cls}" aria-live="polite">${k.value}</div>
+         </article>`
+    )
+    .join("");
 }
 
 // Ženkliukai statusui.

--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,48 @@
 .status-pill { border-radius: 9999px; padding: .125rem .5rem; font-weight: 600; display: inline-block; max-width: 100%; white-space: normal; word-break: break-word; text-align: center; }
 .badge      { border-radius: .5rem; padding: .125rem .5rem; font-weight: 600; display: inline-block; max-width: 100%; white-space: normal; word-break: break-word; text-align: center; }
 .card { border-radius: 1rem; box-shadow: 0 8px 20px rgba(0,0,0,.06); }
+.kpi-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: .75rem;
+  min-height: 7rem;
+  padding: 1rem 1.25rem;
+  height: 100%;
+}
+.kpi-title {
+  margin: 0;
+  font-size: .75rem;
+  font-weight: 700;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: #1e293b;
+  line-height: 1.25;
+  max-width: 100%;
+  word-break: break-word;
+}
+.kpi-value {
+  margin-top: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  font-size: 2.5rem;
+  font-size: clamp(2rem, 3vw + 1rem, 2.75rem);
+  line-height: 1.05;
+  font-weight: 700;
+  border-radius: .75rem;
+  padding: .25rem .75rem;
+}
+.dark .kpi-title { color: #e2e8f0; }
+@media (max-width: 768px) {
+  .kpi-card {
+    min-height: 6.25rem;
+    padding: .75rem 1rem;
+    gap: .5rem;
+  }
+  .kpi-value {
+    font-size: 2.25rem;
+    font-size: clamp(1.75rem, 6vw + .5rem, 2.5rem);
+  }
+}
 .mono { font-variant-numeric: tabular-nums; }


### PR DESCRIPTION
## Summary
- adjust KPI card markup to use semantic headings and aria-labelledby hooks so titles stay anchored inside each card
- expand KPI card layout CSS with flexible spacing and responsive font sizing to keep KPI headings visible across viewports

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c82e470f148320bebbe8e3b219f66e