### PR TITLE
Centralize UI texts for localization

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Minimalus statinis skydelis realiu laiku rodyti lovų būklę iš Google Sheets.
 4. Paspauskite `Atnaujinti` – lentelė turėtų persikrauti be klaidų.
 5. Perjunkite temą mygtuku „Tamsi tema“ ir įsitikinkite, kad stilius keičiasi bei išlieka perkrovus puslapį.
 
+## Naujos kalbos pridėjimas
+1. `texts.js` faile kiekvieno rakto objekte užpildykite naujos kalbos lauką (pvz., `en`) paliktais tuščiais vertimais.
+2. Jei norite, kad nauja kalba būtų numatyta, pakeiskite `DEFAULT_LANG` reikšmę `texts.js` faile (pagal poreikį papildykite loginą kalbos perjungimui).
+3. Atnaujinkite statinius tekstus HTML failuose (`index.html`, `grid.html`) ir datas formatuojančius metodus (`toLocaleString`, `toLocaleTimeString`), kad atitiktų naują kalbą.
+4. Perkraukite puslapį ir patikrinkite, ar visur rodomi teisingi vertimai.
+
 ## Struktūra
 - `index.html` – pagrindinis dashboardas.
 - `data.js` – duomenų įkėlimas ir normalizacija.

--- a/grid.html
+++ b/grid.html
@@ -44,7 +44,7 @@
     </footer>
   </div>
 
-  <script src="theme.js" defer></script>
+  <script type="module" src="theme.js"></script>
   <script type="module" src="grid.js"></script>
 </body>
 </html>

--- a/grid.js
+++ b/grid.js
@@ -1,6 +1,7 @@
 import { loadData } from './data.js';
 import { bedLayout } from './layout.js';
 import { pillForOccupancy } from './utils/ui.js';
+import { texts, t } from './texts.js';
 
 let lastRows = [];
 const grid = document.getElementById('bedGrid');
@@ -65,13 +66,14 @@ async function refresh() {
     renderGrid(rows);
     const updatedEl = document.getElementById('updatedAt');
     if (updatedEl) {
-      const prefix = navigator.onLine ? 'Atnaujinta: ' : 'Offline, rodoma talpykla: ';
+      const prefix = navigator.onLine ? t(texts.updates.onlinePrefix) : t(texts.updates.offlinePrefix);
       updatedEl.textContent = prefix + new Date().toLocaleTimeString('lt-LT');
     }
   } catch (err) {
-    console.error('Nepavyko įkelti duomenų', err);
+    const loadError = t(texts.messages.loadErrorShort);
+    console.error(loadError, err);
     if (errorEl) {
-      errorEl.textContent = 'Nepavyko įkelti duomenų';
+      errorEl.textContent = loadError;
       errorEl.classList.remove('hidden');
     }
   }

--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@
     </div>
   </div>
 
-  <script src="theme.js" defer></script>
+  <script type="module" src="theme.js"></script>
   <script type="module" src="app.js"></script>
 </body>
 </html>

--- a/texts.js
+++ b/texts.js
@@ -1,0 +1,53 @@
+/**
+ * Centralizuotas tekstų žodynas.
+ * `lt` – numatyta kalba, `en` laukeliai palikti būsimiems vertimams.
+ */
+export const DEFAULT_LANG = "lt";
+
+export const texts = {
+  theme: {
+    dark: { lt: "Tamsi tema", en: "" },
+    light: { lt: "Šviesi tema", en: "" },
+  },
+  kpi: {
+    needsCleaning: { lt: "Reikia sutvarkyti", en: "" },
+    occupied: { lt: "Užimta", en: "" },
+    cleaned: { lt: "Sutvarkyta", en: "" },
+    slaBreached: { lt: "SLA viršyta", en: "" },
+  },
+  sla: {
+    exceeded: { lt: "⛔ Viršyta", en: "" },
+    justFreed: { lt: "⚠️ Ką tik atlaisvinta", en: "" },
+    waitingWithin: { lt: "⚪ Laukia (≤ SLA)", en: "" },
+    onTime: { lt: "✅ Atlikta laiku", en: "" },
+  },
+  common: {
+    dash: { lt: "—", en: "" },
+  },
+  time: {
+    hours: { lt: "val", en: "" },
+    minutes: { lt: "min", en: "" },
+  },
+  updates: {
+    onlinePrefix: { lt: "Atnaujinta: ", en: "" },
+    offlinePrefix: { lt: "Offline, rodoma talpykla: ", en: "" },
+  },
+  messages: {
+    loadError: { lt: "Klaida įkeliant duomenis.", en: "" },
+    loadErrorShort: { lt: "Nepavyko įkelti duomenų", en: "" },
+  },
+};
+
+export const currentLang = DEFAULT_LANG;
+
+/**
+ * Grąžina vertimą pagal aktyvią kalbą.
+ * Jei pasirinkta kalba neturi teksto, naudojama numatyta `lt`.
+ * @param {{[key: string]: string}} entry
+ * @param {string} [lang=currentLang]
+ * @returns {string}
+ */
+export function t(entry, lang = currentLang) {
+  if (!entry) return "";
+  return entry[lang] || entry[DEFAULT_LANG] || "";
+}

--- a/theme.js
+++ b/theme.js
@@ -1,18 +1,27 @@
-(function() {
-  const KEY = 'theme';
-  const root = document.documentElement;
-  const btn = document.getElementById('themeToggle');
-  function apply(t) {
-    root.classList.toggle('dark', t === 'dark');
-    if (btn) btn.textContent = t === 'dark' ? 'Šviesi tema' : 'Tamsi tema';
-  }
-  const stored = localStorage.getItem(KEY) || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
-  apply(stored);
+import { texts, t } from "./texts.js";
+
+const STORAGE_KEY = "theme";
+const root = document.documentElement;
+const btn = document.getElementById("themeToggle");
+
+function applyTheme(mode) {
+  root.classList.toggle("dark", mode === "dark");
   if (btn) {
-    btn.addEventListener('click', () => {
-      const next = root.classList.contains('dark') ? 'light' : 'dark';
-      localStorage.setItem(KEY, next);
-      apply(next);
-    });
+    const label = mode === "dark" ? t(texts.theme.light) : t(texts.theme.dark);
+    btn.textContent = label;
   }
-})();
+}
+
+const stored =
+  localStorage.getItem(STORAGE_KEY) ||
+  (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+
+applyTheme(stored);
+
+if (btn) {
+  btn.addEventListener("click", () => {
+    const next = root.classList.contains("dark") ? "light" : "dark";
+    localStorage.setItem(STORAGE_KEY, next);
+    applyTheme(next);
+  });
+}


### PR DESCRIPTION
## Summary
- add a shared `texts.js` dictionary with Lithuanian strings and empty English placeholders
- switch app, grid and theme scripts to read labels from the centralized dictionary and convert the theme helper to a module
- update HTML includes and documentation with guidance for adding new languages

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c863d37e4883208d742f039eb3817c