### PR TITLE
Add coverage for status prioritization and data loading

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,10 +5,10 @@ import { pillForOccupancy } from "./utils/ui.js";
 // Funkcija statuso prioritetui: 🧹 (0) > 🚫 (1) > 🟩 (2).
 function statusPriority(s) {
   if (!s) return 99;
-  const ch = s.trim().charAt(0);
-  if (ch === "🧹") return 0;
-  if (ch === "🚫") return 1;
-  if (ch === "🟩") return 2;
+  const trimmed = s.trim();
+  if (trimmed.startsWith("🧹")) return 0;
+  if (trimmed.startsWith("🚫")) return 1;
+  if (trimmed.startsWith("🟩")) return 2;
   return 9;
 }
 
@@ -195,4 +195,4 @@ if (typeof document !== "undefined" && document.getElementById("refreshBtn")) {
 
 
 
-export { formatDuration, applyFilters };
+export { formatDuration, applyFilters, statusPriority };

--- a/tests/loadData.test.js
+++ b/tests/loadData.test.js
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { loadData } from '../data.js';
+
+const createLocalStorageMock = () => {
+  const store = new Map();
+  return {
+    getItem: vi.fn((key) => (store.has(key) ? store.get(key) : null)),
+    setItem: vi.fn((key, value) => {
+      store.set(key, value);
+    }),
+    removeItem: vi.fn((key) => {
+      store.delete(key);
+    }),
+    clear: vi.fn(() => {
+      store.clear();
+    }),
+    __store: store,
+  };
+};
+
+describe('loadData', () => {
+  let fetchMock;
+  let papaParseMock;
+  let localStorageMock;
+  let consoleErrorSpy;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock;
+
+    localStorageMock = createLocalStorageMock();
+    globalThis.localStorage = localStorageMock;
+
+    papaParseMock = vi.fn();
+    globalThis.Papa = { parse: papaParseMock };
+
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete globalThis.fetch;
+    delete globalThis.Papa;
+    delete globalThis.localStorage;
+  });
+
+  it('grąžina normalizuotas eilutes kai CSV sėkmingai įkeltas', async () => {
+    const csvText = 'mock csv';
+    const response = { text: vi.fn().mockResolvedValue(csvText) };
+    fetchMock.mockResolvedValue(response);
+
+    const rawRows = [
+      {
+        'Lova': 'A1',
+        'Būsena': '🧹 Tvarkyti',
+        'Kontrolė': '⛔ Viršyta',
+        'Užimtumas': 'Užimta',
+        'Atlaisvinta prieš': '1,5',
+        'Paskutinė būsena': 'Pastaba',
+        'Pažymėjo': 'Jonas',
+      },
+    ];
+
+    papaParseMock.mockImplementation((csv, options) => {
+      options.complete({ data: rawRows });
+    });
+
+    const rows = await loadData();
+
+    const expectedRows = [
+      {
+        order: 0,
+        lova: 'A1',
+        galutine: '🧹 Tvarkyti',
+        sla: '⛔ Viršyta',
+        uzimt: 'Užimta',
+        gHours: '1,5',
+        gHoursNum: 1.5,
+        pask: 'Pastaba',
+        who: 'Jonas',
+      },
+    ];
+
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('docs.google.com'), { cache: 'no-store' });
+    expect(response.text).toHaveBeenCalledTimes(1);
+    expect(papaParseMock).toHaveBeenCalledWith(csvText, expect.objectContaining({ header: true, skipEmptyLines: true }));
+    expect(rows).toEqual(expectedRows);
+    expect(localStorageMock.setItem).toHaveBeenCalledWith('cachedRows', JSON.stringify(expectedRows));
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it('grąžina talpyklos duomenis kai fetch meta klaidą', async () => {
+    const cachedRows = [
+      {
+        order: 3,
+        lova: 'B2',
+        galutine: '🚫 Užimta',
+        sla: '⚠️ Ką tik atlaisvinta',
+        uzimt: 'Ligonis',
+        gHours: '0,5',
+        gHoursNum: 0.5,
+        pask: 'Laukiame',
+        who: 'Asta',
+      },
+    ];
+
+    localStorageMock.__store.set('cachedRows', JSON.stringify(cachedRows));
+    fetchMock.mockRejectedValue(new Error('Network klaida'));
+
+    const rows = await loadData();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(localStorageMock.getItem).toHaveBeenCalledWith('cachedRows');
+    expect(rows).toEqual(cachedRows);
+    expect(localStorageMock.setItem).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+});

--- a/tests/statusPriority.test.js
+++ b/tests/statusPriority.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { statusPriority } from '../app.js';
+
+describe('statusPriority', () => {
+  it('grąžina 0 už 🧹 statusą (su tarpais pradžioje)', () => {
+    expect(statusPriority('   🧹 Tvarkyti')).toBe(0);
+  });
+
+  it('grąžina 1 už 🚫 statusą', () => {
+    expect(statusPriority('🚫 Užimta')).toBe(1);
+  });
+
+  it('grąžina 2 už 🟩 statusą', () => {
+    expect(statusPriority('🟩 Laisva')).toBe(2);
+  });
+
+  it('grąžina 9 už nežinomą ikoną', () => {
+    expect(statusPriority('⚠️ Laukia')).toBe(9);
+  });
+
+  it('grąžina 99 kai statusas neapibrėžtas', () => {
+    expect(statusPriority(null)).toBe(99);
+    expect(statusPriority('')).toBe(99);
+  });
+});


### PR DESCRIPTION
## Summary
- fix `statusPriority` emoji detection to handle surrogate pairs correctly and export it for reuse
- add unit tests that verify every returned priority value
- create loadData tests that stub fetch and cover success plus cache fallback paths

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8653e71888320883a499e8f928a7e