### PR TITLE
Improve tablet layout responsiveness

### DIFF
--- a/app.js
+++ b/app.js
@@ -158,14 +158,14 @@ function renderTable(rows) {
   tbody.innerHTML = rows
     .map(
       (r) => `
-        <tr class="odd:bg-slate-50 even:bg-white dark:odd:bg-slate-800 dark:even:bg-slate-900 hover:bg-slate-100 dark:hover:bg-slate-700">
-          <td class="px-4 py-3 text-lg font-medium">${r.lova || dash}</td>
-          <td class="px-4 py-3 text-lg">${pillForStatus(r.galutine)}</td>
-          <td class="px-4 py-3 text-lg">${pillForSLA(r.sla)}</td>
-          <td class="px-4 py-3 text-lg">${pillForOccupancy(r.uzimt)}</td>
-          <td class="px-4 py-3 text-lg">${pillForWait(r.gHoursNum)}</td>
-          <td class="px-4 py-3 text-lg">${r.pask || dash}</td>
-          <td class="px-4 py-3 text-lg">${r.who || dash}</td>
+        <tr class="odd:bg-slate-50 even:bg-white dark:odd:bg-slate-800 dark:even:bg-slate-900 hover:bg-slate-100 dark:hover:bg-slate-700 text-sm md:text-base">
+          <td class="px-3 md:px-4 py-3 text-base md:text-lg font-semibold md:font-medium leading-6 md:leading-7 align-top whitespace-nowrap">${r.lova || dash}</td>
+          <td class="px-3 md:px-4 py-3 text-sm md:text-lg leading-6 md:leading-7 align-top">${pillForStatus(r.galutine)}</td>
+          <td class="px-3 md:px-4 py-3 text-sm md:text-lg leading-6 md:leading-7 align-top">${pillForSLA(r.sla)}</td>
+          <td class="px-3 md:px-4 py-3 text-sm md:text-lg leading-6 md:leading-7 align-top">${pillForOccupancy(r.uzimt)}</td>
+          <td class="px-3 md:px-4 py-3 text-sm md:text-lg leading-6 md:leading-7 align-top">${pillForWait(r.gHoursNum)}</td>
+          <td class="px-3 md:px-4 py-3 text-sm md:text-lg leading-6 md:leading-7 align-top break-words">${r.pask || dash}</td>
+          <td class="px-3 md:px-4 py-3 text-sm md:text-lg leading-6 md:leading-7 align-top break-words">${r.who || dash}</td>
         </tr>
       `
     )

--- a/grid.html
+++ b/grid.html
@@ -25,12 +25,12 @@
   <div class="w-full flex-1 p-4 md:p-8 flex flex-col">
     <header class="flex items-center justify-between mb-2 flex-wrap gap-1">
       <div class="flex items-center gap-1">
-        <button id="listViewBtn" type="button" class="rounded-md bg-slate-900 text-white px-2 py-1 h-7 text-xs shadow hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200">Sąrašo vaizdas</button>
-        <button id="refreshBtn" type="button" class="rounded-md bg-slate-900 text-white px-2 py-1 h-7 text-xs shadow hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200">Atnaujinti</button>
+        <button id="listViewBtn" type="button" class="rounded-md bg-slate-900 text-white px-2 py-1 h-9 text-xs shadow hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200">Sąrašo vaizdas</button>
+        <button id="refreshBtn" type="button" class="rounded-md bg-slate-900 text-white px-2 py-1 h-9 text-xs shadow hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200">Atnaujinti</button>
       </div>
       <div class="flex items-center gap-1">
         <span id="updatedAt" class="text-sm text-slate-500 dark:text-slate-400">—</span>
-        <button id="themeToggle" type="button" class="rounded-md bg-slate-900 text-white px-2 py-1 h-7 text-xs shadow hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200">Tamsi tema</button>
+        <button id="themeToggle" type="button" class="rounded-md bg-slate-900 text-white px-2 py-1 h-9 text-xs shadow hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200">Tamsi tema</button>
       </div>
     </header>
     <div id="error" class="text-red-600 mb-2 hidden"></div>

--- a/index.html
+++ b/index.html
@@ -38,21 +38,21 @@
     <header class="flex flex-col md:flex-row md:items-center gap-1 md:gap-2 md:justify-between mb-2">
       <div>
         <h1 class="text-xl md:text-2xl font-semibold">Lovų būklė</h1>
-        <button id="gridViewBtn" type="button" class="rounded-md bg-slate-900 text-white px-2 py-1 h-7 text-xs shadow hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200">Tinklelio vaizdas</button>
+        <button id="gridViewBtn" type="button" class="rounded-md bg-slate-900 text-white px-2 py-1 h-9 text-xs shadow hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200">Tinklelio vaizdas</button>
         </div>
-        <div class="flex flex-wrap md:flex-nowrap items-center gap-1 text-sm overflow-x-auto">
+        <div class="toolbar text-sm">
           <label for="search" class="sr-only">Paieška</label>
           <input id="search" type="search" placeholder="Paieška (lova, būsena, pažymėjo)…"
-                 class="md:w-64 w-full border rounded-md px-2 py-1 h-7 flex-none bg-white shadow-sm focus:outline-none text-xs dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100 dark:placeholder-slate-400">
+                 class="md:w-64 w-full border rounded-md px-2 py-1 h-9 bg-white shadow-sm focus:outline-none text-xs dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100 dark:placeholder-slate-400">
           <label for="filterStatus" class="sr-only">Filtruoti pagal būseną</label>
-          <select id="filterStatus" class="border rounded-md px-2 py-1 h-7 flex-none bg-white shadow-sm text-xs dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100">
+          <select id="filterStatus" class="border rounded-md px-2 py-1 h-9 bg-white shadow-sm text-xs dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100">
           <option value="">Visos būsenos</option>
           <option value="🧹">🧹 Reikia sutvarkyti</option>
           <option value="🚫">🚫 Užimta</option>
           <option value="🟩">🟩 Sutvarkyta</option>
         </select>
           <label for="filterSLA" class="sr-only">Filtruoti pagal SLA</label>
-          <select id="filterSLA" class="border rounded-md px-2 py-1 h-7 flex-none bg-white shadow-sm text-xs dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100">
+          <select id="filterSLA" class="border rounded-md px-2 py-1 h-9 bg-white shadow-sm text-xs dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100">
           <option value="">SLA – visos</option>
           <option value="⛔ Viršyta">⛔ Viršyta</option>
           <option value="⚠️ Ką tik atlaisvinta">⚠️ Ką tik atlaisvinta</option>
@@ -60,18 +60,18 @@
           <option value="✅ Atlikta laiku">✅ Atlikta laiku</option>
         </select>
           <label for="sort" class="sr-only">Rikiavimo seka</label>
-          <select id="sort" class="border rounded-md px-2 py-1 h-7 flex-none bg-white shadow-sm text-xs dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100">
+          <select id="sort" class="border rounded-md px-2 py-1 h-9 bg-white shadow-sm text-xs dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100">
           <option value="priority">Rikiuoti pagal prioritetą</option>
           <option value="bed">Rikiuoti pagal lovą</option>
           <option value="wait">Pagal laukimo laiką (desc)</option>
         </select>
-        <button id="refreshBtn" type="button" class="rounded-md bg-slate-900 text-white px-2 py-1 h-7 flex-none text-xs shadow hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200">
+        <button id="refreshBtn" type="button" class="rounded-md bg-slate-900 text-white px-2 py-1 h-9 text-xs shadow hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200">
           Atnaujinti
         </button>
-        <button id="clearFilters" type="button" class="rounded-md bg-slate-900 text-white px-2 py-1 h-7 flex-none text-xs shadow hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200">
+        <button id="clearFilters" type="button" class="rounded-md bg-slate-900 text-white px-2 py-1 h-9 text-xs shadow hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200">
           Išvalyti
         </button>
-        <button id="themeToggle" type="button" class="rounded-md bg-slate-900 text-white px-2 py-1 h-7 flex-none text-xs shadow hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200">
+        <button id="themeToggle" type="button" class="rounded-md bg-slate-900 text-white px-2 py-1 h-9 text-xs shadow hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200">
           Tamsi tema
         </button>
       </div>
@@ -83,16 +83,16 @@
     <!-- Lentelė -->
     <div class="card bg-white overflow-hidden dark:bg-slate-800 dark:text-slate-100">
       <div class="overflow-auto max-h-[70vh]">
-        <table class="min-w-full text-lg leading-7">
-          <thead class="sticky top-0 z-10 bg-slate-100/70 text-slate-700 dark:bg-slate-700 dark:text-slate-200">
+        <table class="min-w-full leading-7 responsive-table">
+          <thead class="sticky top-0 z-10 bg-slate-100/70 text-slate-700 dark:bg-slate-700 dark:text-slate-200 text-xs md:text-sm">
             <tr>
-              <th class="text-left px-4 py-2">Lova</th>
-              <th class="text-left px-4 py-2">Galutinė būsena</th>
-              <th class="text-left px-4 py-2">SLA būsena</th>
-              <th class="text-left px-4 py-2">Užimtumas</th>
-              <th class="text-left px-4 py-2">Atlaisvinta prieš</th>
-              <th class="text-left px-4 py-2">Paskutinė būsena</th>
-              <th class="text-left px-4 py-2">Kas pažymėjo</th>
+              <th class="text-left px-3 md:px-4 py-2">Lova</th>
+              <th class="text-left px-3 md:px-4 py-2">Galutinė būsena</th>
+              <th class="text-left px-3 md:px-4 py-2">SLA būsena</th>
+              <th class="text-left px-3 md:px-4 py-2">Užimtumas</th>
+              <th class="text-left px-3 md:px-4 py-2">Atlaisvinta prieš</th>
+              <th class="text-left px-3 md:px-4 py-2">Paskutinė būsena</th>
+              <th class="text-left px-3 md:px-4 py-2">Kas pažymėjo</th>
             </tr>
           </thead>
           <tbody id="tbody" class="divide-y divide-slate-200 dark:divide-slate-700"></tbody>

--- a/styles.css
+++ b/styles.css
@@ -45,4 +45,71 @@
     font-size: clamp(1.75rem, 6vw + .5rem, 2.5rem);
   }
 }
+.toolbar {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: .5rem;
+  align-items: center;
+  width: 100%;
+}
+.toolbar > * {
+  width: 100%;
+}
+@media (min-width: 768px) {
+  .toolbar {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: .75rem;
+  }
+}
+@media (min-width: 1024px) {
+  .toolbar {
+    display: flex;
+    flex-wrap: nowrap;
+    gap: .75rem;
+  }
+  .toolbar > * {
+    width: auto;
+  }
+  .toolbar input[type="search"] {
+    min-width: 16rem;
+  }
+}
+.responsive-table {
+  border-collapse: separate;
+  border-spacing: 0;
+}
+.responsive-table th,
+.responsive-table td {
+  vertical-align: top;
+}
+.responsive-table td {
+  word-break: break-word;
+}
+@media (max-width: 1280px) {
+  .responsive-table th,
+  .responsive-table td {
+    padding-left: .75rem;
+    padding-right: .75rem;
+  }
+  .responsive-table td .status-pill,
+  .responsive-table td .badge {
+    font-size: .9rem;
+  }
+}
+@media (max-width: 1024px) {
+  .responsive-table {
+    font-size: 1rem;
+    line-height: 1.5;
+  }
+  .responsive-table th {
+    font-size: .75rem;
+    letter-spacing: .02em;
+  }
+  .kpi-card {
+    min-height: 6.5rem;
+  }
+  .kpi-value {
+    font-size: clamp(1.6rem, 3vw + .75rem, 2.25rem);
+  }
+}
 .mono { font-variant-numeric: tabular-nums; }


### PR DESCRIPTION
## Summary
- convert the list view toolbar into a responsive grid so search and filter controls wrap cleanly on tablets
- tweak table markup and styling for smaller typography, consistent padding, and better text wrapping on medium screens
- align button sizing across list and grid views for easier tapping and adjust CSS helpers for tablet-friendly KPI scaling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ccd952d8388320919bc3b4078992c9