### PR TITLE
Add critical alerts with audio toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,11 +74,17 @@
         <button id="themeToggle" type="button" class="rounded-md bg-slate-900 text-white px-2 py-1 h-9 text-xs shadow hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200">
           Tamsi tema
         </button>
+        <button id="audioToggle" type="button" class="rounded-md bg-slate-900 text-white px-2 py-1 h-9 text-xs shadow hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200" aria-pressed="false">
+          Garso signalai
+        </button>
       </div>
     </header>
 
     <!-- KPI kortelės -->
     <section id="kpis" class="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6"></section>
+
+    <!-- Pranešimai apie kritinius įvykius -->
+    <div id="alerts" class="hidden mb-4 rounded-md border border-amber-400 bg-amber-50 px-4 py-3 text-sm font-medium text-amber-900 shadow-sm dark:border-amber-500 dark:bg-amber-900/40 dark:text-amber-100" role="status" aria-live="assertive"></div>
 
     <!-- Lentelė -->
     <div class="card bg-white overflow-hidden dark:bg-slate-800 dark:text-slate-100">

--- a/styles.css
+++ b/styles.css
@@ -113,3 +113,15 @@
   }
 }
 .mono { font-variant-numeric: tabular-nums; }
+.pulse-critical {
+  animation: criticalPulse 1.5s ease-in-out infinite;
+}
+
+@keyframes criticalPulse {
+  0%, 100% {
+    background-color: inherit;
+  }
+  50% {
+    background-color: rgba(250, 204, 21, 0.25);
+  }
+}

--- a/tests/criticalDetection.test.js
+++ b/tests/criticalDetection.test.js
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { buildCriticalSet, detectNewCritical } from "../app.js";
+
+describe("detectNewCritical", () => {
+  beforeEach(() => {
+    if (typeof localStorage !== "undefined") {
+      localStorage.clear();
+    }
+  });
+
+  it("identifies naujus SLA ir valymo įrašus", () => {
+    const previous = buildCriticalSet([
+      { order: 0, lova: "101", galutine: "🟩 Sutvarkyta", sla: "⚪ Laukia (≤ SLA)" },
+    ]);
+    const { newOnes } = detectNewCritical(previous, [
+      { order: 0, lova: "101", galutine: "🧹 Reikia sutvarkyti", sla: "⚪ Laukia (≤ SLA)" },
+      { order: 1, lova: "102", galutine: "🚫 Užimta", sla: "⛔ Viršyta" },
+    ]);
+    expect(newOnes).toContain("cleaning|101");
+    expect(newOnes).toContain("sla|102");
+  });
+
+  it("nežymi pasikartojančių kritinių būsenų", () => {
+    const previous = new Set(["cleaning|101", "sla|row-2"]);
+    const { newOnes } = detectNewCritical(previous, [
+      { order: 0, lova: "101", galutine: "🧹 Reikia sutvarkyti", sla: "" },
+      { order: 2, lova: "", galutine: "", sla: "⛔ Viršyta" },
+    ]);
+    expect(newOnes).toHaveLength(0);
+  });
+
+  it("naudoja eilės indeksą, kai trūksta lovos kodo", () => {
+    const { newOnes } = detectNewCritical(new Set(), [
+      { order: 5, lova: "", galutine: "🧹 Reikia sutvarkyti", sla: "" },
+      { order: 6, galutine: "", sla: "⛔ Viršyta" },
+    ]);
+    expect(newOnes).toContain("cleaning|row-5");
+    expect(newOnes).toContain("sla|row-6");
+  });
+});

--- a/texts.js
+++ b/texts.js
@@ -35,6 +35,10 @@ export const texts = {
   messages: {
     loadError: { lt: "Klaida įkeliant duomenis.", en: "" },
     loadErrorShort: { lt: "Nepavyko įkelti duomenų", en: "" },
+    newSlaBreach: { lt: "Naujas SLA viršijimas", en: "" },
+    needsCleaningAlert: { lt: "Reikia sutvarkyti lovą", en: "" },
+    soundOn: { lt: "Garso signalai įjungti", en: "" },
+    soundOff: { lt: "Garso signalai išjungti", en: "" },
   },
 };
 


### PR DESCRIPTION
## Summary
- detect new critical (⛔/🧹) rows between refreshes, surface them in a notification banner, and optionally play stored audio tones
- add a toolbar audio toggle with persisted preference plus pulsing table rows for the highlighted beds
- extend localization strings and cover the detection helper with Vitest unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cce0247e4883208f799dcbffe7954a