### PR TITLE
Refactor refresh workflow to use cached state

### DIFF
--- a/tests/appFilters.test.js
+++ b/tests/appFilters.test.js
@@ -1,5 +1,4 @@
-// @vitest-environment jsdom
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { applyFilters } from '../app.js';
 
 const sampleRows = [
@@ -8,36 +7,21 @@ const sampleRows = [
   { lova: 'C1', galutine: '🟩 Sutvarkyta', sla: '✅ Atlikta laiku', uzimt: '', pask: '', who: '', gHoursNum: 0 }
 ];
 
-function setupDom() {
-  document.body.innerHTML = `
-    <input id="search" value="" />
-    <select id="filterStatus"><option value=""></option><option value="🧹">🧹</option></select>
-    <select id="filterSLA"><option value=""></option><option value="⛔ Viršyta">⛔ Viršyta</option></select>
-  `;
-}
-
 describe('applyFilters', () => {
-  beforeEach(() => {
-    setupDom();
-  });
-
   it('filters by status', () => {
-    document.getElementById('filterStatus').value = '🧹';
-    const res = applyFilters(sampleRows);
+    const res = applyFilters(sampleRows, { status: '🧹' });
     expect(res).toHaveLength(1);
     expect(res[0].lova).toBe('A1');
   });
 
   it('filters by SLA', () => {
-    document.getElementById('filterSLA').value = '⛔ Viršyta';
-    const res = applyFilters(sampleRows);
+    const res = applyFilters(sampleRows, { sla: '⛔ Viršyta' });
     expect(res).toHaveLength(1);
     expect(res[0].lova).toBe('A1');
   });
 
   it('filters by search query', () => {
-    document.getElementById('search').value = 'c1';
-    const res = applyFilters(sampleRows);
+    const res = applyFilters(sampleRows, { query: 'c1' });
     expect(res).toHaveLength(1);
     expect(res[0].lova).toBe('C1');
   });


### PR DESCRIPTION
## Summary
- cache loaded rows and highlight state so reloads and rendering are decoupled
- refactor filtering and sorting helpers to accept an explicit UI state object and update listeners accordingly
- adjust unit tests to call the new helper signatures without depending on DOM shims

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dae6a2020c8320bb0bd83162da1697